### PR TITLE
support double pinyin with Projection

### DIFF
--- a/scripts/lua/baidu.lua
+++ b/scripts/lua/baidu.lua
@@ -8,20 +8,30 @@ local function make_url(input, bg, ed)
       '&result=hanzi&resultcoding=utf-8&ch_en=0&clientinfo=web&version=1'
 end
 
-local function translator(input, seg)
-   local url = make_url(input, 0, 5)
+local function translator(input, seg, env)
+   local config = env.engine.schema.config
+   local config_list= config:get_list("translator/preedit_format")
+   local delimiter = config:get_string("speller/delimiter"):sub(1, 1) -- 获取首个字符为分隔符，常见为空格
+
+   local projection = Projection(config_list)
+   local p_str = projection:apply(input, true)
+
+   local url = make_url(p_str, 0, 5)
    local reply = http.request(url)
    local _, j = pcall(json.decode, reply)
    if j.status == "T" and j.result and j.result[1] then
-      for i, v in ipairs(j.result[1]) do
-	 local c = Candidate("simple", seg.start, seg.start + v[2], v[1], "(百度云拼音)")
-	 c.quality = 2
-	 if string.gsub(v[3].pinyin, "'", "") == string.sub(input, 1, v[2]) then
-	    c.preedit = string.gsub(v[3].pinyin, "'", " ")
-	 end
-	 yield(c)
+      for ii, vv in ipairs(j.result) do
+         for i, v in ipairs(vv) do
+            local hanzi = v[1]
+            local pylen = v[2]
+            local py = v[3].pinyin
+            local c = Candidate("simple", seg.start, seg.start + pylen, hanzi, "(百度云拼音)")
+            c.quality = 2
+            c.preedit = string.gsub(py, "'", delimiter) -- 避免编码区显示为原始输入字符串
+            yield(c)
+         end
       end
-   end   
+   end
 end
 
 return translator

--- a/scripts/lua/trigger.lua
+++ b/scripts/lua/trigger.lua
@@ -1,15 +1,16 @@
 local function make(trig_key, trig_translator)
    local flag = false
-
+   local last_script_text = ""
    local function processor(key, env)
       local kAccepted = 1
       local kNoop = 2
       local engine = env.engine
       local context = engine.context
-
       if key:repr() == trig_key then
 	 if context:is_composing() then
-	    flag = true
+      last_script_text = context:get_script_text()
+      last_script_text = string.gsub(last_script_text, " ", "'")
+      flag = true
 	    context:refresh_non_confirmed_composition()
 	    return kAccepted
 	 end
@@ -21,7 +22,7 @@ local function make(trig_key, trig_translator)
    local function translator(input, seg, env)
       if flag then
 	 flag = false
-	 trig_translator(input, seg, env)
+    trig_translator(last_script_text, seg, env)
       end
    end
 


### PR DESCRIPTION
解决 #14 的需求1。

无需自定义码表。
已测试：double_pinyin_flypy 小鹤双拼-薄荷定制，luna_quanpin 全拼。

没看到`c.preedit`被`if`的正面意义，所以最终PR中去除了。例如，启用首字母简拼，小鹤双拼，b ih（bu chang）在有if、触发云检索后显示为`bih`，去掉if则正确显示云端返回的bu chang 补偿，选中其他候选词时仍正常显示b chang。